### PR TITLE
Removed object-curly-newline rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+<a name="1.0.5"></a>
+# 1.0.5
+
+1. [x] Removed: `object-curly-newline` rule ([#5](https://github.com/kiforks/eslint-config-kifor/pull/5)) ([@kiforks](https://github.com/kiforks)).
+
 <a name="1.0.4"></a>
 # 1.0.4
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "eslint-config-kifor",
 	"description": "eslint shareable config",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"engines": {
 		"node": ">=20.8.1"
 	},

--- a/typescript.js
+++ b/typescript.js
@@ -17,15 +17,6 @@ module.exports = {
 		'no-restricted-globals': 'off',
 		'no-return-assign': 'off',
 		'no-underscore-dangle': 'off',
-		'object-curly-newline': [
-			'error',
-			{
-				ExportDeclaration: { multiline: true },
-				ImportDeclaration: { multiline: true },
-				ObjectExpression: { minProperties: 8, multiline: true },
-				ObjectPattern: { minProperties: 8, multiline: true },
-			},
-		],
 		'padded-blocks': 'off',
 		'prefer-destructuring': 'off',
 		radix: ['error', 'as-needed'],


### PR DESCRIPTION
1. [x] Removed: `object-curly-newline` rule ([#5](https://github.com/kiforks/eslint-config-kifor/pull/5)) ([@kiforks](https://github.com/kiforks)).