### PR TITLE
Fix `@typescript-eslint/lines-between-class-members` rule 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <a name="1.1.5"></a>
 # 1.1.5
 
-1. [x] Fix `@typescript-eslint/lines-between-class-members` rule ([25](https://github.com/kiforks/eslint-config-kifor/pull/24)) ([@kiforks](https://github.com/kiforks)).
+1. [x] Fix `@typescript-eslint/lines-between-class-members` rule ([25](https://github.com/kiforks/eslint-config-kifor/pull/25)) ([@kiforks](https://github.com/kiforks)).
 
 <a name="1.1.4"></a>
 # 1.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+<a name="1.1.5"></a>
+# 1.1.5
+
+1. [x] Fix `@typescript-eslint/lines-between-class-members` rule ([25](https://github.com/kiforks/eslint-config-kifor/pull/24)) ([@kiforks](https://github.com/kiforks)).
+
 <a name="1.1.4"></a>
 # 1.1.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "eslint-config-kifor",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "eslint-config-kifor",
-			"version": "1.1.3",
+			"version": "1.1.4",
 			"license": "MIT",
 			"dependencies": {
 				"@angular-eslint/builder": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "eslint-config-kifor",
 	"description": "eslint shareable config",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"engines": {
 		"node": ">=20.8.1"
 	},

--- a/typescript.js
+++ b/typescript.js
@@ -2,7 +2,7 @@ module.exports = {
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 	plugins: ['@typescript-eslint', '@stylistic/js', '@stylistic/ts', 'max-params-no-constructor'],
 	rules: {
-		'@typescript-eslint/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+		'@typescript-eslint/lines-between-class-members': ['error', { exceptAfterSingleLine: true }],
 		'@typescript-eslint/no-explicit-any': 'off',
 		'@typescript-eslint/no-extraneous-class': ['error', { allowEmpty: true, allowStaticOnly: true }],
 		'@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],


### PR DESCRIPTION
1. [x] Fix `@typescript-eslint/lines-between-class-members` rule 